### PR TITLE
ci(meta): add missing package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "cloudeck",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "prepare": "husky install"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1",
+    "husky": "^9.1.7"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sanzuu0/Cloudeck.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sanzuu0/Cloudeck/issues"
+  },
+  "homepage": "https://github.com/sanzuu0/Cloudeck#readme"
+}


### PR DESCRIPTION
## Description
`package.json` was omitted in the previous PR with Husky/Commitlint.
Without it, local Git hooks are not installed after `npm i`.

### What was done
- Added **package.json** with:
- devDeps: husky ^9.1.7, @commitlint/cli & config-conventional ^19.8.1
- scripts.prepare="husky install"

### How to verify
1. `npm ci`
2. `git commit --allow-empty -m "fix(api): test commit"` → commit passes
3. `git commit --allow-empty -m "bad commit"` → commitlint rejects.

### Checklist
- [ x ] CI is green
- [ x ] Husky hooks install on `npm i`.
- [ x ] Documentation not needed
- [ x ] Branch rebased on latest `main`